### PR TITLE
redirect /linux.html to /releases for CentOS instructions (resolves #36)

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -6,6 +6,7 @@ redirect_from:
     - "/downloadCPA/"
     - "/downloadCPA.html"
     - "/downloadCPA.shtml"
+    - "/linux.html"
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
related to [#2383](https://github.com/CellProfiler/CellProfiler/issues/2383)