### PR TITLE
add redirect from /CellProfiler-Analyst to /cpa

### DIFF
--- a/cpa/index.html
+++ b/cpa/index.html
@@ -1,7 +1,7 @@
 ---
 redirect_from:
     - "/CPA"
-    - "CellProfiler-Analyst"
+    - "/CellProfiler-Analyst"
 ---
 <!DOCTYPE html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->

--- a/cpa/index.html
+++ b/cpa/index.html
@@ -1,6 +1,7 @@
 ---
 redirect_from:
     - "/CPA"
+    - "CellProfiler-Analyst"
 ---
 <!DOCTYPE html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->


### PR DESCRIPTION
@mcquin is deleting the CellProfiler-Analyst gh-page branch from CellProfiler/CellProfiler-Analyst gh repo and this redirect will tie up loose ends. 